### PR TITLE
Adds tests for GStrings for command in exec()

### DIFF
--- a/src/test/groovy/com/aestasit/ssh/SshDslTest.groovy
+++ b/src/test/groovy/com/aestasit/ssh/SshDslTest.groovy
@@ -252,4 +252,21 @@ class SshDslTest extends BaseSshTest {
     }
   }
 
+  @Test
+  void testExecGStringCommand() throws Exception {
+    def cmd = 'whoami'
+    engine.remoteSession {
+      assert exec(command: "$cmd", showOutput: true).output.trim() == 'root'
+    }
+  }
+
+  @Test
+  void testExecGStringCommandArray() throws Exception {
+    def cmd = 'whoami'
+    List cmds = ["$cmd", "$cmd"]
+    engine.remoteSession {
+      exec(command: cmds, showOutput: true)
+    }
+  }
+
 }


### PR DESCRIPTION
Adds tests for #56, which looks like it's been resolved since the 0.9.16 release.
