### PR TITLE
Ansi colors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   compile "commons-codec:commons-codec:${commonsCodecVersion}"
   compile "com.jcraft:jsch:${jschVersion}"
   compile "com.lexicalscope.jewelcli:jewelcli:${jewelcliVersion}"
+  compile 'org.fusesource.jansi:jansi:1.11'
   testCompile "junit:junit:${junitVersion}"
   testCompile "com.aestasit.infrastructure.mock:groovy-sshd-mock:0.3"
   testCompile "com.github.stefanbirkner:system-rules:1.16.0"

--- a/src/main/groovy/com/aestasit/infrastructure/ssh/log/AnsiLogger.groovy
+++ b/src/main/groovy/com/aestasit/infrastructure/ssh/log/AnsiLogger.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2011-2014 Aestas/IT
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aestasit.infrastructure.ssh.log
+
+import org.fusesource.jansi.AnsiConsole
+import static org.fusesource.jansi.Ansi.*
+import static org.fusesource.jansi.Ansi.Color.*
+
+/**
+ * LIST OF COLORS
+ *
+ * "BLACK"), 
+ * "RED"), 
+ * "GREEN"), 
+ * "YELLOW"), 
+ * "BLUE"), 
+ * "MAGENTA"), 
+ * "CYAN"), 
+ * "WHITE"),
+ * "DEFAULT");
+ */
+
+class AnsiLogger implements Logger {
+
+  public AnsiLogger() {
+  	AnsiConsole.systemInstall()
+  }	
+  
+  def void info(String message) {
+
+    println (ansi().fg(BLUE).a(message).reset())
+
+  }
+
+  def void warn(String message) {
+  	println (ansi().fg(YELLOW).a(message).reset())
+  }
+
+  def void debug(String message) {
+    println (ansi().fg(GREEN).a(message).reset())
+  }
+
+}


### PR DESCRIPTION
Added AnsiLogger class that uses jansi library to output "colored" log.
It extends the default Logger interface, therefore only `debug`,`info`,`warn` levels are available.