### PR TITLE
Adds ability to hide secrets from logging output

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,8 @@ The `sshOptions` may also contain a nested `execOptions` structure, which define
 
  - `showOutput` (defaults to true) - If set to true, remote command output is printed.
  - `showCommand` (defaults to true) - If set to true, remote command is printed.
+ - `hideSecrets` (defaults to true) - If set to true, secret Strings contained in ExecOptions.secrets will be redacted from output and replaced by `********`.
+ - `secrets` (defaults to [ ]) - a list of secret Strings to be redacted from output
  - `maxWait` (defaults to 0) - Number of milliseconds to wait for command to finish. If it is set to 0, then library will wait forever.
  - `succeedOnExitStatus` (defaults to 0) - Exit code that indicates commands success. If command returns different exit code, then build will fail.
  - `failOnError` (defaults to true) - If set to true, failed remote commands will fail the build.
@@ -375,6 +377,8 @@ options.with {
   execOptions.with {
     showOutput = true
     failOnError = false
+    hideSecrets = true
+    secrets = ['secret1']
     succeedOnExitStatus = 0
     maxWait = 30000
   }

--- a/src/main/groovy/com/aestasit/infrastructure/ssh/ExecOptions.groovy
+++ b/src/main/groovy/com/aestasit/infrastructure/ssh/ExecOptions.groovy
@@ -31,6 +31,7 @@ class ExecOptions extends CommonOptions {
 
   Boolean showOutput       = true
   Boolean showCommand      = true
+  Boolean hideSecrets      = true
   Long maxWait             = 0
 
   Long succeedOnExitStatus = 0
@@ -39,6 +40,7 @@ class ExecOptions extends CommonOptions {
   String prefix            = null
   String suffix            = null
   def escapeCharacters     = null
+  List<String> secrets     = []
 
   ExecOptions() {
   }
@@ -47,12 +49,14 @@ class ExecOptions extends CommonOptions {
     this.failOnError         = setValue(opt1?.failOnError, true)
     this.showOutput          = setValue(opt1?.showOutput, true)
     this.showCommand         = setValue(opt1?.showCommand, true)
+    this.hideSecrets         = setValue(opt1?.hideSecrets, true)
     this.maxWait             = setValue(opt1?.maxWait, 0L)
     this.succeedOnExitStatus = setValue(opt1?.succeedOnExitStatus, 0L)
     this.usePty              = setValue(opt1?.usePty, true)
     this.prefix              = setValue(opt1?.prefix, null)
     this.suffix              = setValue(opt1?.suffix, null)
     this.escapeCharacters    = setValue(opt1?.escapeCharacters, null)    
+    this.secrets             = setValue(opt1?.secrets, null)
   }
 
   ExecOptions(ExecOptions opt1, ExecOptions opt2) {
@@ -63,12 +67,14 @@ class ExecOptions extends CommonOptions {
     this.failOnError         = setValue(opt2?.failOnError, opt1?.failOnError, true)
     this.showOutput          = setValue(opt2?.showOutput, opt1?.showOutput, true)
     this.showCommand         = setValue(opt2?.showCommand, opt1?.showCommand, true)
+    this.hideSecrets         = setValue(opt2?.hideSecrets, opt1?.hideSecrets, true)
     this.maxWait             = setValue(opt2?.maxWait as Long, opt1?.maxWait, 0L)
     this.succeedOnExitStatus = setValue(opt2?.succeedOnExitStatus as Long, opt1?.succeedOnExitStatus, 0L)
     this.usePty              = setValue(opt2?.usePty, opt1?.usePty, true)
     this.prefix              = setValue(opt2?.prefix, opt1?.prefix, null)
     this.suffix              = setValue(opt2?.suffix, opt1?.suffix, null)
     this.escapeCharacters    = setValue(opt2?.escapeCharacters, opt1?.escapeCharacters, null)
+    this.secrets             = setValue(opt2?.secrets, opt1?.secrets, null) as List<String>
   }
 
 }

--- a/src/test/groovy/com/aestasit/infrastructure/ssh/ExecOptionsTest.groovy
+++ b/src/test/groovy/com/aestasit/infrastructure/ssh/ExecOptionsTest.groovy
@@ -31,6 +31,7 @@ class ExecOptionsTest {
     def defaultOpts = new ExecOptions()
     assert defaultOpts.failOnError
     assert defaultOpts.showOutput
+    assert defaultOpts.hideSecrets
     def opts = new ExecOptions(defaultOpts, [ failOnError: false ] )
     assert !opts.failOnError
   }

--- a/src/test/groovy/com/aestasit/infrastructure/ssh/SshDslTest.groovy
+++ b/src/test/groovy/com/aestasit/infrastructure/ssh/SshDslTest.groovy
@@ -264,6 +264,17 @@ class SshDslTest extends BaseSshTest {
   }
 
   @Test
+  void testRedacting() {
+    String output = captureOutput {
+      engine.remoteSession {
+        exec(command: './script.sh username secret1 secret2', secrets: ['secret1', 'secret2'])
+      }
+    }
+    assert !output.contains('secret1')
+    assert !output.contains('secret2')
+  }
+
+  @Test
   void testPrefix() {
     String output = captureOutput {
       engine.remoteSession {


### PR DESCRIPTION
This fixes #60 by adding a `hideSecrets` flag to `ExecOptions`. When true, secret Strings set in `ExecOptions.secrets` will be redacted from logging output. 

Here is some sample output where `showCommands = true`, `showOutput = true`, and `hideSecrets = true`:
```
...
exec(command: './script.sh username secret1 secret2', secrets: ['secret1', 'secret2'])

>>> Connecting to 127.0.0.1
> ./script.sh username ******** ********
Unknown command: ./script.sh username ******** ********
WARN: Remote command failed with exit status -1
```