### PR TITLE
Fix problem with python files

### DIFF
--- a/src/main/groovy/com/aestasit/infrastructure/ssh/dsl/RemoteFile.groovy
+++ b/src/main/groovy/com/aestasit/infrastructure/ssh/dsl/RemoteFile.groovy
@@ -258,6 +258,38 @@ class RemoteFile implements Appendable, Writable {
     }
   }
 
+  /**
+   * Sets remote file content as text.
+   *
+   * @param text content to set.
+   * @param trim if true, text is trimmed.
+   */
+  void setText(String text, boolean trim) {
+    File tempFile = createTempFile()
+    if (trim) {
+        tempFile.withWriter { writer ->
+            text.readLines().each { String line ->
+                writer.append("${line.trim()}\n")
+            }
+        }
+    } else {
+        tempFile.withWriter { writer ->
+            text.readLines().each { String line ->
+                writer.append("${line}\n")
+            }
+        }
+    }
+
+    try {
+      delegate.scp {
+        from { localFile(tempFile) }
+        into { remoteFile(destination) }
+      }
+    } finally {
+      tempFile.delete()
+    }
+  }
+
   @SuppressWarnings('FactoryMethodName')
   private File createTempFile() {
     File.createTempFile(this.getClass().package.name, 'txt')


### PR DESCRIPTION
I'm trying something like:

``` groovy
    remoteFile("${OCSG_HOME}/ocsg-domain.py").setText(ocsgDomainFile
        .replaceAll('REPLACE_WITH_ADMIN_PASSWORD', ADMIN_PASSWORD)
        )
```

but it's failing because setText has a trim which delete tabs, mandatory for python files. I generate a new setText which allows to use or not the trim function:

``` groovy
    remoteFile("${OCSG_HOME}/ocsg-domain.py").setText(ocsgDomainFile
        .replaceAll('REPLACE_WITH_ADMIN_PASSWORD', ADMIN_PASSWORD),
        false
        )
```

Probably trim() isn't needed but I've preferred to maintain it for back-ward compatibility.
