### PR TITLE
✨Allow key file path in keyFile param

### DIFF
--- a/subprojects/sshoogr/src/main/groovy/com/aestasit/infrastructure/ssh/dsl/SessionDelegate.groovy
+++ b/subprojects/sshoogr/src/main/groovy/com/aestasit/infrastructure/ssh/dsl/SessionDelegate.groovy
@@ -108,9 +108,9 @@ class SessionDelegate {
         session = jsch.getSession(username, host, port)
         if (keyFile != null) {
           if (passPhrase) {
-            jsch.addIdentity(keyFile.absolutePath, passPhrase)
+            jsch.addIdentity(keyFile instanceof String ? new File(keyFile).absolutePath : keyFile.absolutePath, passPhrase)
           } else {
-            jsch.addIdentity(keyFile.absolutePath)
+            jsch.addIdentity(keyFile instanceof String ? new File(keyFile).absolutePath : keyFile.absolutePath)
           }
         }
 


### PR DESCRIPTION
Allow to set key file path instead of File object to make available to use from Jenkins pipeline.